### PR TITLE
Add missing mail type filter

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -588,6 +588,8 @@ function bp_registration_options_send_pending_user_email( $args = array() ) {
 	 * @param array $args Array of wp_mail args.
 	 */
 	$args = apply_filters( 'bprwg_pending_user_email_args', $args );
+	
+	add_filter( 'wp_mail_content_type', 'bp_registration_options_set_content_type' );
 
 	wp_mail( $args['user_email'], __( 'Pending Membership', 'bp-registration-options' ), $args['message'] );
 


### PR DESCRIPTION
Make bp_registration_options_send_pending_user_email() modify the mail type the same way as bp_registration_options_send_admin_email().

For testing try to add br-tags or headline-tags to the user pending mail in admin and send it. In Apple Mail and some Webmailer I could see the tags show up.
https://cloudup.com/ihaoaDEUNn5
https://cloudup.com/i_YmfmCyz-v