### PR TITLE
add filter for users who receive bp notifications

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -58,7 +58,7 @@ function bp_registration_options_bp_core_register_account( $user_id ) {
 		/**
 		 * Filters the users to set notifications for new members.
 		 *
-		 * @since 4.3.2
+		 * @since 4.3.4
 		 *
 		 * @param array $value Array of users to set notifications for new members.
 		 */

--- a/includes/core.php
+++ b/includes/core.php
@@ -55,7 +55,14 @@ function bp_registration_options_bp_core_register_account( $user_id ) {
 		/** This filter is documented in includes/core.php */
 		//$admin_email = apply_filters( 'bprwg_admin_email_addresses', array( get_bloginfo( 'admin_email' ) ) );
 		// Used for BP Notifications.
-		$admins = get_users( 'role=administrator' );
+		/**
+		 * Filters the users to set notifications for new members.
+		 *
+		 * @since 4.3.2
+		 *
+		 * @param array $value Array of users to set notifications for new members.
+		 */
+		$admins = apply_filters( 'bprwg_bp_notification_users', get_users( 'role=administrator' ) );
 
 		// Add HTML capabilities temporarily.
 		add_filter( 'wp_mail_content_type', 'bp_registration_options_set_content_type' );


### PR DESCRIPTION
There already exists a filter for users who receive email notifications of new registrations. So this completes the ability for other plugins to change the users who can moderate registrations.